### PR TITLE
Fix login query parameters and service call

### DIFF
--- a/src/main/java/com/ecom/demo/eecom/repository/UserRepository.java
+++ b/src/main/java/com/ecom/demo/eecom/repository/UserRepository.java
@@ -13,7 +13,7 @@ public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByEmail(String email);
 
     // Custom SQL query for login
-    @Query(value = "SELECT * FROM user WHERE email = :emailId AND password = :pword", nativeQuery = true)
+    @Query(value = "SELECT * FROM user WHERE email = :email AND password = :password", nativeQuery = true)
     Optional<User> dbLoginWithQuery(@Param("email") String email, @Param("password") String password);
 
 

--- a/src/main/java/com/ecom/demo/eecom/service/AuthService.java
+++ b/src/main/java/com/ecom/demo/eecom/service/AuthService.java
@@ -117,8 +117,8 @@ public class AuthService {
 
   @Transactional
   public Object loginWithSqlQuery(LoginApiDetails loginApiDetails) {
-    Optional<User> dbData = userRepository.dbLoginWithStoredProcedure(loginApiDetails.getEmail(),
-        loginApiDetails.getPassword());
+    Optional<User> dbData =
+        userRepository.dbLoginWithQuery(loginApiDetails.getEmail(), loginApiDetails.getPassword());
     if (dbData.isPresent()) {
       return dbData.get();
     } else {


### PR DESCRIPTION
## Summary
- correct named parameters in the custom query of `UserRepository`
- use the query-based repository method in `AuthService.loginWithSqlQuery`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68410dd209ac832d8e9234bf6e6e55e5